### PR TITLE
Update Panel (Terminal) border color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v1.1.1
+- Update panel border color
+
 ## v1.1.0
 - Improve MarkDown file syntax highlighting
 

--- a/themes/blueberry-dark-theme-color-theme.json
+++ b/themes/blueberry-dark-theme-color-theme.json
@@ -55,7 +55,7 @@
 		"tab.unfocusedActiveForeground": "#a6accd",
 		"editorGroupHeader.tabsBackground": "#1d212f",
 		"editorGroup.border": "#00000030",
-		"panel.border": "#242938",
+		"panel.border": "393f59",
 		"panelTitle.activeForeground": "#a6accd",
 		"statusBar.foreground": "#676e95",
 		"statusBar.background": "#1d212f",

--- a/themes/blueberry-dark-theme-color-theme.json
+++ b/themes/blueberry-dark-theme-color-theme.json
@@ -55,7 +55,7 @@
 		"tab.unfocusedActiveForeground": "#a6accd",
 		"editorGroupHeader.tabsBackground": "#1d212f",
 		"editorGroup.border": "#00000030",
-		"panel.border": "393f59",
+		"panel.border": "#393f59",
 		"panelTitle.activeForeground": "#a6accd",
 		"statusBar.foreground": "#676e95",
 		"statusBar.background": "#1d212f",


### PR DESCRIPTION
Hi Peyman,
I've changed the Terminal panel border color (based on your color palette) for more clarity.
As you see, the editor and terminal sections have no border; I hope this commit fixes it.

![Screenshot from 2021-12-07 18-13-58](https://user-images.githubusercontent.com/10072527/145050411-35503c5d-ad2c-4469-9ca7-91a40145fa4f.png)